### PR TITLE
Only run code review if the `claude-review` label is present

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, labeled]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"
@@ -12,6 +12,7 @@ on:
 
 jobs:
   claude-review:
+    if: contains(github.event.pull_request.labels.*.name, 'claude-review')
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||


### PR DESCRIPTION
I don't actually want claude to review every PR, only if I ask it. 